### PR TITLE
docs: Specify commit message template

### DIFF
--- a/.git-commit-template.txt
+++ b/.git-commit-template.txt
@@ -1,0 +1,30 @@
+# <type>: (If applied, this commit will...) <subject> (Max 50 char)
+# |<----  Using a Maximum Of 50 Characters  ---->|
+
+
+# Explain why this change is being made
+# |<----   Try To Limit Each Line to a Maximum Of 72 Characters   ---->|
+
+# Provide links or keys to any relevant tickets, articles or other resources
+# Example: Github issue #23
+
+# --- COMMIT END ---
+# Type can be 
+#    feat     (new feature)
+#    fix      (bug fix)
+#    refactor (refactoring production code)
+#    style    (formatting, missing semi colons, etc; no code change)
+#    docs     (changes to documentation)
+#    test     (adding or refactoring tests; no production code change)
+#    chore    (updating grunt tasks etc; no production code change)
+# --------------------
+# Remember to
+#    Capitalize the subject line
+#    Use the imperative mood in the subject line
+#    Do not end the subject line with a period
+#    Separate subject from body with a blank line
+#    Use the body to explain what and why vs. how
+#    Can use multiple lines with "-" for bullet points in body
+# --------------------
+# For more information about this template, check out
+# https://gist.github.com/adeekshith/cd4c95a064977cdc6c50

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ CMakeLists.txt.user*
 
 *.pro.user*
 .*
+!.git-commit-template.txt
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ This project's goal is to create a simple way to mount a directory located on a 
 
 ## Coding style
 This project uses the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html), with the exception of using tabs instead of spaces.
+
+## Commit Message Template
+Please set .git-commit-template.txt as your commit message template and follow the rules.
+To do so, simply run below command in project root directory:
+
+`git config commit.template .git-commit-template.txt`
+
+Read this [post](https://chris.beams.io/posts/git-commit/) for more info.


### PR DESCRIPTION
This commit adds a commit message template as well as it's how to. This
makes messages more coherent and consistent.