### PR TITLE
feat: Add check to make sure the target paths are within the allowed mount directory

### DIFF
--- a/Common/common.h
+++ b/Common/common.h
@@ -305,6 +305,7 @@ inline QByteArray getSystemInfo() {
     if (SystemStr.endsWith('|'))
         SystemStr.truncate(SystemStr.length() - 1);
 
+    qCritical() << SystemStr;
     return SystemStr;
 }
 

--- a/SSNFS-client/fuseclient.cpp
+++ b/SSNFS-client/fuseclient.cpp
@@ -159,8 +159,10 @@ int FuseClient::fs_opt_proc(void *data, const char *arg, int key, fuse_args *out
 
     case FUSE_OPT_KEY_NONOPT:
     {
+        //qInfo() << arg;
         QString strArg(arg);
         if (host.isNull() && shareName.isNull() && strArg.count(QLatin1Char('/')) == 1) {
+
             QStringList parts = strArg.split('/');
             QStringList hostParts = parts[0].split(':');
             host = hostParts[0];
@@ -184,6 +186,7 @@ int FuseClient::fs_opt_proc(void *data, const char *arg, int key, fuse_args *out
                 system(ToChr(fuseUnmount));
             }
             QFileInfo mountPathInfo(strArg);
+            qCritical() << strArg ;
             if (mountPathInfo.exists() == false || !mountPathInfo.isDir() || mountPathInfo.isSymLink()) {
                 qCritical() << "The specified mount path does not exist or is not a valid directory.";
                 return -1;
@@ -205,9 +208,8 @@ int FuseClient::fs_opt_proc(void *data, const char *arg, int key, fuse_args *out
 
 void FuseClient::started() {
     connect(&passwdWatcher, SIGNAL(fileChanged(QString)), this, SLOT(syncLocalUsers()), Qt::QueuedConnection);
-
     struct fuse_operations fs_oper = {};
-
+    qInfo() << qApp->arguments();
     fs_oper.init = fs_call_init;
     fs_oper.getattr = fs_call_getattr;
     fs_oper.readdir = fs_call_readdir;
@@ -313,8 +315,9 @@ int FuseClient::initSocket()
 
         socket->setCaCertificates(QSslSocket::systemCaCertificates());
         socket->setPeerVerifyMode(QSslSocket::VerifyNone);
-        socket->setPrivateKey("/home/maxwell/Coding/SSNFS/SSNFS-client/key.pem");
-        socket->setLocalCertificate("/home/maxwell/Coding/SSNFS/SSNFS-client/cert.pem");
+        // Does not given an error if these files are not found but does not mount as well
+        socket->setPrivateKey("/home/deepakchethan/Git/build-SSNFS-Desktop-Debug/SSNFS-client/key.pem");
+        socket->setLocalCertificate("/home/deepakchethan/Git/build-SSNFS-Desktop-Debug/SSNFS-client/cert.pem");
 
         socket->connectToHostEncrypted(host, port);
 

--- a/SSNFSd/ssnfsworker.h
+++ b/SSNFSd/ssnfsworker.h
@@ -40,6 +40,7 @@ public:
     void run() override;
 
     QString getPerms(QString path, qint32 uid);
+    QByteArray isValidPath(QByteArray path);
     void ReadyToRead();
     void processHttpRequest(char firstChar);
 
@@ -51,7 +52,6 @@ public:
     bool working = false;
     QHash<int, int> fds;
     QTime timer;
-
     qint64 userKey = -1;
     qint64 clientKey = -1;
     QString clientName;


### PR DESCRIPTION
If I removed the qCritical() and qInfo() message, the arguments are not being parsed correctly. So I retained them. Let me know if any changes need to be done.
Github issue #2